### PR TITLE
[JENKINS-26477] SimpleBuildWrapper integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.444</version>
+        <version>1.598-SNAPSHOT</version> <!-- TODO SimpleBuildWrapper-JENKINS-24673 -->
     </parent>
 
   <artifactId>xvnc</artifactId>
@@ -18,7 +18,13 @@
         <email>levon.sa@gmail.com</email>
     </developer>
   </developers>
-  <scm>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
+    <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
@@ -26,7 +32,48 @@
   </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <workflow.version>1.2-SNAPSHOT</workflow.version> <!-- TODO SimpleBuildWrapper-JENKINS-24673 -->
   </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency> <!-- StepConfigTester -->
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>${workflow.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency> <!-- SemaphoreStep -->
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>${workflow.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
   <build>
       <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.599-SNAPSHOT</version> <!-- TODO SimpleBuildWrapper-JENKINS-24673 -->
+        <version>1.599</version>
     </parent>
 
   <artifactId>xvnc</artifactId>
@@ -43,38 +43,38 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>${workflow.version}</version>
+            <version>1.3-20150216.230634-1</version> <!-- TODO ${workflow.version} -->
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>${workflow.version}</version>
+            <version>1.3-20150216.230541-1</version> <!-- TODO ${workflow.version} -->
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>${workflow.version}</version>
+            <version>1.3-20150216.230609-1</version> <!-- TODO ${workflow.version} -->
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>${workflow.version}</version>
+            <version>1.3-20150216.230548-1</version> <!-- TODO ${workflow.version} -->
             <scope>test</scope>
         </dependency>
         <dependency> <!-- StepConfigTester -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>${workflow.version}</version>
+            <version>1.3-20150216.230508-1</version> <!-- TODO ${workflow.version} -->
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- SemaphoreStep -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>${workflow.version}</version>
+            <version>1.3-20150216.230528-1</version> <!-- TODO ${workflow.version} -->
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.598-SNAPSHOT</version> <!-- TODO SimpleBuildWrapper-JENKINS-24673 -->
+        <version>1.599-SNAPSHOT</version> <!-- TODO SimpleBuildWrapper-JENKINS-24673 -->
     </parent>
 
   <artifactId>xvnc</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.599</version>
+        <version>1.609.1</version>
     </parent>
 
   <artifactId>xvnc</artifactId>
@@ -37,44 +37,51 @@
   </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <workflow.version>1.2-SNAPSHOT</workflow.version> <!-- TODO SimpleBuildWrapper-JENKINS-24673 -->
+    <workflow.version>1.8</workflow.version>
   </properties>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>1.3-20150216.230634-1</version> <!-- TODO ${workflow.version} -->
+            <version>${workflow.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>1.3-20150216.230541-1</version> <!-- TODO ${workflow.version} -->
+            <version>${workflow.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>1.3-20150216.230609-1</version> <!-- TODO ${workflow.version} -->
+            <version>${workflow.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>1.3-20150216.230548-1</version> <!-- TODO ${workflow.version} -->
+            <version>${workflow.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- StepConfigTester -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>1.3-20150216.230508-1</version> <!-- TODO ${workflow.version} -->
+            <version>${workflow.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency> <!-- SemaphoreStep -->
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>1.3-20150216.230528-1</version> <!-- TODO ${workflow.version} -->
+            <version>${workflow.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency> <!-- JenkinsRuleExt -->
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-aggregator</artifactId>
+            <version>${workflow.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/hudson/plugins/xvnc/DisplayAllocator.java
+++ b/src/main/java/hudson/plugins/xvnc/DisplayAllocator.java
@@ -73,14 +73,16 @@ final class DisplayAllocator {
     @Restricted(NoExternalUse.class)
     /*package*/ static final class Property extends NodeProperty<Node> {
 
-        private transient /*final*/ DisplayAllocator allocator = new DisplayAllocator();
+        private /*final*/ DisplayAllocator allocator = new DisplayAllocator();
 
         /*package*/ DisplayAllocator getAllocator() {
             return allocator;
         }
 
         private Object readResolve() {
-            allocator = new DisplayAllocator();
+            if (allocator == null) {
+                allocator = new DisplayAllocator();
+            }
             return this;
         }
 

--- a/src/main/java/hudson/plugins/xvnc/Xvnc.java
+++ b/src/main/java/hudson/plugins/xvnc/Xvnc.java
@@ -164,11 +164,15 @@ public class Xvnc extends SimpleBuildWrapper {
             PrintStream logger = listener.getLogger();
             if (takeScreenshot) {
                 logger.println(Messages.Xvnc_TAKING_SCREENSHOT());
-                launcher.launch().cmds("echo", "$XAUTHORITY").envs(xauthorityEnv).stdout(logger).pwd(workspace).join();
-                launcher.launch().cmds("ls", "-l", "$XAUTHORITY").envs(xauthorityEnv).stdout(logger).pwd(workspace).join();
-                launcher.launch().cmds("import", "-window", "root", "-display", ":" + displayNumber, FILENAME_SCREENSHOT).
-                        envs(xauthorityEnv).stdout(logger).pwd(workspace).join();
-                build.getArtifactManager().archive(workspace, launcher, new BuildListenerAdapter(listener), Collections.singletonMap(FILENAME_SCREENSHOT, FILENAME_SCREENSHOT));
+                try {
+                    launcher.launch().cmds("echo", "$XAUTHORITY").envs(xauthorityEnv).stdout(logger).pwd(workspace).join();
+                    launcher.launch().cmds("ls", "-l", "$XAUTHORITY").envs(xauthorityEnv).stdout(logger).pwd(workspace).join();
+                    launcher.launch().cmds("import", "-window", "root", "-display", ":" + displayNumber, FILENAME_SCREENSHOT).
+                            envs(xauthorityEnv).stdout(logger).pwd(workspace).join();
+                    build.getArtifactManager().archive(workspace, launcher, new BuildListenerAdapter(listener), Collections.singletonMap(FILENAME_SCREENSHOT, FILENAME_SCREENSHOT));
+                } catch (Exception x) {
+                    x.printStackTrace(logger);
+                }
             }
             logger.println(Messages.Xvnc_TERMINATING());
             if (vncserverCommand != null) {

--- a/src/main/java/hudson/plugins/xvnc/Xvnc.java
+++ b/src/main/java/hudson/plugins/xvnc/Xvnc.java
@@ -85,6 +85,7 @@ public class Xvnc extends SimpleBuildWrapper {
             cmd = "vncserver :$DISPLAY_NUMBER -localhost -nolisten tcp";
         }
 
+        workspace.mkdirs();
         doSetUp(context, build, workspace, node, launcher, logger, cmd, 10, DESCRIPTOR.minDisplayNumber,
                 DESCRIPTOR.maxDisplayNumber);
     }

--- a/src/main/java/hudson/plugins/xvnc/Xvnc.java
+++ b/src/main/java/hudson/plugins/xvnc/Xvnc.java
@@ -1,29 +1,33 @@
 package hudson.plugins.xvnc;
 
+import hudson.AbortException;
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Proc;
 import hudson.Util;
-import hudson.model.BuildListener;
-import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Computer;
-import hudson.model.Hudson;
 import hudson.model.Node;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
 import hudson.util.FormValidation;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.WeakHashMap;
+import javax.annotation.CheckForNull;
 
 import jenkins.model.Jenkins;
+import jenkins.tasks.SimpleBuildWrapper;
+import jenkins.util.BuildListenerAdapter;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -35,7 +39,7 @@ import org.kohsuke.stapler.StaplerRequest;
  *
  * @author Kohsuke Kawaguchi
  */
-public class Xvnc extends BuildWrapper {
+public class Xvnc extends SimpleBuildWrapper {
     /**
      * Whether or not to take a screenshot upon completion of the build.
      */
@@ -52,23 +56,28 @@ public class Xvnc extends BuildWrapper {
     }
 
     @Override
-    public Environment setUp(AbstractBuild build, final Launcher launcher, BuildListener listener)
+    public void setUp(Context context, Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener, EnvVars initialEnvironment)
             throws IOException, InterruptedException {
         final PrintStream logger = listener.getLogger();
-        DescriptorImpl DESCRIPTOR = Hudson.getInstance().getDescriptorByType(DescriptorImpl.class);
+        DescriptorImpl DESCRIPTOR = Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class);
 
         // skip xvnc execution
-        if (build.getBuiltOn().getAssignedLabels().contains(Jenkins.getInstance().getLabelAtom("noxvnc"))
-                || build.getBuiltOn().getNodeProperties().get(NodePropertyImpl.class) != null) {
-            return new Environment(){};
+        Computer c = workspace.toComputer();
+        Node node = c != null ? c.getNode() : null;
+        if (node == null) {
+            throw new AbortException("No node recognized for " + workspace);
+        }
+        if (node.getAssignedLabels().contains(Jenkins.getInstance().getLabelAtom("noxvnc"))
+                || node.getNodeProperties().get(NodePropertyImpl.class) != null) {
+            return;
         }
 
         if (DESCRIPTOR.skipOnWindows && !launcher.isUnix()) {
-            return new Environment(){};
+            return;
         }
 
         if (DESCRIPTOR.cleanUp) {
-            maybeCleanUp(launcher, listener);
+            maybeCleanUp(launcher, listener, node);
         }
 
         String cmd = Util.nullify(DESCRIPTOR.xvnc);
@@ -76,15 +85,15 @@ public class Xvnc extends BuildWrapper {
             cmd = "vncserver :$DISPLAY_NUMBER -localhost -nolisten tcp";
         }
 
-        return doSetUp(build, launcher, logger, cmd, 10, DESCRIPTOR.minDisplayNumber,
+        doSetUp(context, build, workspace, node, launcher, logger, cmd, 10, DESCRIPTOR.minDisplayNumber,
                 DESCRIPTOR.maxDisplayNumber);
     }
 
-    private Environment doSetUp(AbstractBuild build, final Launcher launcher, final PrintStream logger,
+    private void doSetUp(Context context, Run<?,?> build, FilePath workspace, Node node, final Launcher launcher, final PrintStream logger,
             String cmd, int retries, int minDisplayNumber, int maxDisplayNumber)
                     throws IOException, InterruptedException {
 
-        final DisplayAllocator allocator = getAllocator(build);
+        final DisplayAllocator allocator = getAllocator(node);
 
         final int displayNumber = allocator.allocate(minDisplayNumber, maxDisplayNumber);
         final String actualCmd = Util.replaceMacro(cmd, Collections.singletonMap("DISPLAY_NUMBER",String.valueOf(displayNumber)));
@@ -93,13 +102,17 @@ public class Xvnc extends BuildWrapper {
 
         String[] cmds = Util.tokenize(actualCmd);
 
-        final FilePath xauthority = build.getWorkspace().createTempFile(".Xauthority-", "");
+        final FilePath xauthority = workspace.createTempFile(".Xauthority-", "");
         final Map<String,String> xauthorityEnv = new HashMap<String, String>();
         if (useXauthority) {
             xauthorityEnv.put("XAUTHORITY", xauthority.getRemote());
+            context.env("XAUTHORITY", xauthority.getRemote());
+        } else {
+            // Need something to identify it by for Launcher.kill in DisposerImpl.
+            xauthorityEnv.put("XVNC_COOKIE", UUID.randomUUID().toString());
         }
 
-        final Proc proc = launcher.launch().cmds(cmds).envs(xauthorityEnv).stdout(logger).pwd(build.getWorkspace()).start();
+        final Proc proc = launcher.launch().cmds(cmds).envs(xauthorityEnv).stdout(logger).pwd(workspace).start();
         final String vncserverCommand;
         if (cmds[0].endsWith("vncserver") && cmd.contains(":$DISPLAY_NUMBER")) {
             // Command just started the server; -kill will stop it.
@@ -113,8 +126,9 @@ public class Xvnc extends BuildWrapper {
                 //allocator.free(displayNumber);
                 allocator.blacklist(displayNumber);
                 if (retries > 0) {
-                    return doSetUp(build, launcher, logger, cmd, retries - 1,
+                    doSetUp(context, build, workspace, node, launcher, logger, cmd, retries - 1,
                             minDisplayNumber, maxDisplayNumber);
+                    return;
                 } else {
                     throw new IOException(message);
                 }
@@ -123,47 +137,61 @@ public class Xvnc extends BuildWrapper {
             vncserverCommand = null;
         }
 
-        return new Environment() {
+        context.env("DISPLAY", ":" + displayNumber);
+        context.setDisposer(new DisposerImpl(displayNumber, xauthorityEnv, vncserverCommand, takeScreenshot, xauthority.getRemote()));
+    }
+    
+    private static class DisposerImpl extends Disposer {
+        
+        private static final long serialVersionUID = 1;
+        
+        private final int displayNumber;
+        private final Map<String,String> xauthorityEnv;
+        private final @CheckForNull String vncserverCommand;
+        private final boolean takeScreenshot;
+        private final String xauthorityPath;
 
-                @Override
-            public void buildEnvVars(Map<String, String> env) {
-                env.put("DISPLAY",":"+displayNumber);
-                env.putAll(xauthorityEnv);
+        DisposerImpl(int displayNumber, Map<String,String> xauthorityEnv, @CheckForNull String vncserverCommand, boolean takeScreenshot, String xauthorityPath) {
+            this.displayNumber = displayNumber;
+            this.xauthorityEnv = xauthorityEnv;
+            this.vncserverCommand = vncserverCommand;
+            this.takeScreenshot = takeScreenshot;
+            this.xauthorityPath = xauthorityPath;
+        }
+        
+        @Override public void tearDown(Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+            PrintStream logger = listener.getLogger();
+            if (takeScreenshot) {
+                logger.println(Messages.Xvnc_TAKING_SCREENSHOT());
+                launcher.launch().cmds("echo", "$XAUTHORITY").envs(xauthorityEnv).stdout(logger).pwd(workspace).join();
+                launcher.launch().cmds("ls", "-l", "$XAUTHORITY").envs(xauthorityEnv).stdout(logger).pwd(workspace).join();
+                launcher.launch().cmds("import", "-window", "root", "-display", ":" + displayNumber, FILENAME_SCREENSHOT).
+                        envs(xauthorityEnv).stdout(logger).pwd(workspace).join();
+                build.getArtifactManager().archive(workspace, launcher, new BuildListenerAdapter(listener), Collections.singletonMap(FILENAME_SCREENSHOT, FILENAME_SCREENSHOT));
             }
-
-            @Override
-            public boolean tearDown(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
-                if (takeScreenshot) {
-                    FilePath ws = build.getWorkspace();
-                    File artifactsDir = build.getArtifactsDir();
-                    artifactsDir.mkdirs();
-                    logger.println(Messages.Xvnc_TAKING_SCREENSHOT());
-                    launcher.launch().cmds("echo", "$XAUTHORITY").envs(xauthorityEnv).stdout(logger).pwd(ws).join();
-                    launcher.launch().cmds("ls", "-l", "$XAUTHORITY").envs(xauthorityEnv).stdout(logger).pwd(ws).join();
-                    launcher.launch().cmds("import", "-window", "root", "-display", ":" + displayNumber, FILENAME_SCREENSHOT).
-                            envs(xauthorityEnv).stdout(logger).pwd(ws).join();
-                    ws.child(FILENAME_SCREENSHOT).copyTo(new FilePath(artifactsDir).child(FILENAME_SCREENSHOT));
-                }
-                logger.println(Messages.Xvnc_TERMINATING());
-                if (vncserverCommand != null) {
-                    // #173: stopping the wrapper script will accomplish nothing. It has already exited, in fact.
-                    launcher.launch().cmds(vncserverCommand, "-kill", ":" + displayNumber).envs(xauthorityEnv).stdout(logger).join();
-                } else {
-                    // Assume it can be shut down by being killed.
-                    proc.kill();
-                }
-                allocator.free(displayNumber);
-                xauthority.delete();
-                return true;
+            logger.println(Messages.Xvnc_TERMINATING());
+            if (vncserverCommand != null) {
+                // #173: stopping the wrapper script will accomplish nothing. It has already exited, in fact.
+                launcher.launch().cmds(vncserverCommand, "-kill", ":" + displayNumber).envs(xauthorityEnv).stdout(logger).join();
+            } else {
+                // Assume it can be shut down by being killed.
+                launcher.kill(xauthorityEnv);
             }
-        };
+            Computer c = workspace.toComputer();
+            Node node = c != null ? c.getNode() : null;
+            if (node == null) {
+                throw new AbortException("No node recognized for " + workspace);
+            }
+            getAllocator(node).free(displayNumber);
+            workspace.child(xauthorityPath).delete();
+        }
     }
 
-    private DisplayAllocator getAllocator(AbstractBuild<?, ?> build) throws IOException {
-        DisplayAllocator.Property property = build.getBuiltOn().getNodeProperties().get(DisplayAllocator.Property.class);
+    private static DisplayAllocator getAllocator(Node node) throws IOException {
+        DisplayAllocator.Property property = node.getNodeProperties().get(DisplayAllocator.Property.class);
         if (property == null) {
             property = new DisplayAllocator.Property();
-            build.getBuiltOn().getNodeProperties().add(property);
+            node.getNodeProperties().add(property);
         }
         return property.getAllocator();
     }
@@ -174,8 +202,7 @@ public class Xvnc extends BuildWrapper {
     private static final Map<Node,Boolean> cleanedUpOn = new WeakHashMap<Node,Boolean>();
 
     // XXX I18N
-    private static synchronized void maybeCleanUp(Launcher launcher, BuildListener listener) throws IOException, InterruptedException {
-        Node node = Computer.currentComputer().getNode();
+    private static synchronized void maybeCleanUp(Launcher launcher, TaskListener listener, Node node) throws IOException, InterruptedException {
         if (cleanedUpOn.put(node, true) != null) {
             return;
         }

--- a/src/test/java/hudson/plugins/xvnc/XvncTest.java
+++ b/src/test/java/hudson/plugins/xvnc/XvncTest.java
@@ -38,6 +38,7 @@ import hudson.util.OneShotEvent;
 
 import java.io.IOException;
 import java.util.concurrent.Future;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/hudson/plugins/xvnc/XvncTest.java
+++ b/src/test/java/hudson/plugins/xvnc/XvncTest.java
@@ -140,20 +140,14 @@ public class XvncTest {
     public void saveComputerWithDisplayAllocatorProperty() throws Exception {
         DumbSlave slave = j.createOnlineSlave();
 
-        configRoundtrip(slave); // Without property
+        j.configRoundtrip(slave); // Without property
 
         FreeStyleProject p = j.jenkins.createProject(FreeStyleProject.class, "project");
         p.setAssignedNode(slave);
         runXvnc(p).cleanUp = true;
         j.buildAndAssertSuccess(p);
 
-        configRoundtrip(slave); // With property
-    }
-
-    // TODO available since 1.479 in JenkinsRule
-    private <N extends Node> N configRoundtrip(N node) throws Exception {
-        j.submit(j.createWebClient().goTo("/computer/" + node.getNodeName() + "/configure").getFormByName("config"));
-        return (N)j.jenkins.getNode(node.getNodeName());
+        j.configRoundtrip(slave); // With property
     }
 
     private Xvnc fakeXvncRun(FreeStyleProject p) throws Exception {

--- a/src/test/java/hudson/plugins/xvnc/XvncTest.java
+++ b/src/test/java/hudson/plugins/xvnc/XvncTest.java
@@ -23,13 +23,11 @@
  */
 package hudson.plugins.xvnc;
 
-import static org.junit.Assert.assertTrue;
 import hudson.Launcher;
 import hudson.model.BuildListener;
 import hudson.model.FreeStyleBuild;
 import hudson.model.Result;
 import hudson.model.AbstractBuild;
-import hudson.model.Descriptor;
 import hudson.model.FreeStyleProject;
 import hudson.model.Hudson;
 import hudson.model.Node;
@@ -128,26 +126,6 @@ public class XvncTest {
 
         runXvnc(p).cleanUp = true;
         j.buildAndAssertSuccess(p);
-    }
-
-    @Test @Bug(25424)
-    public void jenkins25424() {
-        Descriptor<?> desc = j.jenkins.getDescriptorOrDie(DisplayAllocator.Property.class);
-        assertTrue(desc instanceof DisplayAllocator.Property.DescriptorImpl);
-    }
-
-    @Test @Bug(25424)
-    public void saveComputerWithDisplayAllocatorProperty() throws Exception {
-        DumbSlave slave = j.createOnlineSlave();
-
-        j.configRoundtrip(slave); // Without property
-
-        FreeStyleProject p = j.jenkins.createProject(FreeStyleProject.class, "project");
-        p.setAssignedNode(slave);
-        runXvnc(p).cleanUp = true;
-        j.buildAndAssertSuccess(p);
-
-        j.configRoundtrip(slave); // With property
     }
 
     private Xvnc fakeXvncRun(FreeStyleProject p) throws Exception {

--- a/src/test/java/hudson/plugins/xvnc/XvncWorkflowTest.java
+++ b/src/test/java/hudson/plugins/xvnc/XvncWorkflowTest.java
@@ -29,6 +29,7 @@ import hudson.slaves.DumbSlave;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.RetentionStrategy;
 import java.util.Collections;
+import org.jenkinsci.plugins.workflow.JenkinsRuleExt;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -82,10 +83,7 @@ public class XvncWorkflowTest {
                 assertNotNull(p);
                 WorkflowRun b = p.getBuildByNumber(1);
                 assertNotNull(b);
-                while (b.isBuilding()) { // TODO JENKINS-26399 need utility in JenkinsRule
-                    Thread.sleep(100);
-                }
-                story.j.assertBuildStatusSuccess(b);
+                story.j.assertBuildStatusSuccess(JenkinsRuleExt.waitForCompletion(b));
                 story.j.assertLogContains("DISPLAY=:", b);
             }
         });

--- a/src/test/java/hudson/plugins/xvnc/XvncWorkflowTest.java
+++ b/src/test/java/hudson/plugins/xvnc/XvncWorkflowTest.java
@@ -67,7 +67,7 @@ public class XvncWorkflowTest {
                         + "node('slave') {\n"
                         + "  wrap([$class: 'Xvnc']) {\n"
                         + "    semaphore 'withDisplayAfterRestart'\n"
-                        + "    sh 'echo DISPLAY=$DISPLAY; which xmessage && xmessage -timeout 1 hello'\n"
+                        + "    sh 'echo DISPLAY=$DISPLAY; which xmessage && xmessage -timeout 1 hello || :'\n"
                         + "  }\n"
                         + "}", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();

--- a/src/test/java/hudson/plugins/xvnc/XvncWorkflowTest.java
+++ b/src/test/java/hudson/plugins/xvnc/XvncWorkflowTest.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.plugins.xvnc;
+
+import hudson.model.Node;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.RetentionStrategy;
+import java.util.Collections;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.CoreWrapperStep;
+import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+public class XvncWorkflowTest {
+
+    @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test public void configRoundTrip() {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                Xvnc xvnc = new Xvnc(true, false);
+                CoreWrapperStep step = new CoreWrapperStep(xvnc);
+                step = new StepConfigTester(story.j).configRoundTrip(step);
+                story.j.assertEqualDataBoundBeans(xvnc, step.getDelegate());
+            }
+        });
+    }
+
+    @Test public void withDisplayAfterRestart() throws Exception {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                story.j.jenkins.addNode(new DumbSlave("slave", "dummy", tmp.newFolder("remoteFS").getPath(), "1", Node.Mode.NORMAL, "", story.j.createComputerLauncher(null), RetentionStrategy.NOOP, Collections.<NodeProperty<?>>emptyList())); // TODO JENKINS-26398 clumsy
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition(""
+                        + "node('slave') {\n"
+                        + "  wrap([$class: 'Xvnc']) {\n"
+                        + "    semaphore 'withDisplayAfterRestart'\n"
+                        + "    sh 'echo DISPLAY=$DISPLAY; which xmessage && xmessage -timeout 1 hello'\n"
+                        + "  }\n"
+                        + "}", true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                SemaphoreStep.waitForStart("withDisplayAfterRestart/1", b);
+            }
+        });
+        story.addStep(new Statement() {
+            @SuppressWarnings("SleepWhileInLoop")
+            @Override public void evaluate() throws Throwable {
+                SemaphoreStep.success("withDisplayAfterRestart/1", null);
+                WorkflowJob p = story.j.jenkins.getItemByFullName("p", WorkflowJob.class);
+                assertNotNull(p);
+                WorkflowRun b = p.getBuildByNumber(1);
+                assertNotNull(b);
+                while (b.isBuilding()) { // TODO JENKINS-26399 need utility in JenkinsRule
+                    Thread.sleep(100);
+                }
+                story.j.assertBuildStatusSuccess(b);
+                story.j.assertLogContains("DISPLAY=:", b);
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
[JENKINS-26477](https://issues.jenkins-ci.org/browse/JENKINS-26477): make this plugin usable from Workflow.

- [x] basic integration
- [X] functional tests
- [x] flow hangs and cannot be interrupted if `import` not in `$PATH`
- [x] stop using `NodeProperty` to hold `DisplayAllocator`
- [x] manual tests
- [x] use released version of Workflow
- [x] update to LTS (?) release of core

# Manual testing

Tried to test against a Docker slave (`evarga/jenkins-slave` with `vnc4server` and `imagemagick` installed), but it did not work:

    Error: Can't open display: :50

However I get the same error from a freestyle project on the same slave. The flow works when run on `master`. From the XVNC error log I found that I needed to comment out

    x-window-manager &

in `~/.vnc/xstartup`. I also needed to

    chown root.root /tmp/.X11-unix

Whew. With those fixes, finally a test flow works as expected:

```groovy
node('docker') {
  wrap([$class: 'Xvnc', takeScreenshot: true, useXauthority: true]) {
    sh 'xmessage hello &'
  }
}
```