### PR TITLE
fixed pom for importing in Eclipse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,26 @@
                   </execution>
               </executions>
           </plugin>
+		<plugin>
+			<groupId>org.codehaus.mojo</groupId>
+			<artifactId>build-helper-maven-plugin</artifactId>
+			<executions>
+				<!-- Attention Eclipse users: if you see an error here, you have to install 
+					the M2E buildhelper plugin. -->
+				<execution>
+					<id>add-localizer-source-folder</id>
+					<phase>generate-sources</phase>
+					<goals>
+						<goal>add-source</goal>
+					</goals>
+					<configuration>
+						<sources>
+							<source>${project.build.directory}/generated-sources/localizer</source>
+						</sources>
+					</configuration>
+				</execution>
+			</executions>
+		</plugin>
       </plugins>
       <pluginManagement>
       	<plugins>
@@ -192,6 +212,27 @@
       								</versionRange>
       								<goals>
       									<goal>generateTestStubs</goal>
+      									<goal>testCompile</goal>
+      								</goals>
+      							</pluginExecutionFilter>
+      							<action>
+      								<ignore />
+      							</action>
+      						</pluginExecution>
+      						<pluginExecution>
+      							<pluginExecutionFilter>
+      								<groupId>
+      									org.apache.maven.plugins
+      								</groupId>
+      								<artifactId>
+      									maven-enforcer-plugin
+      								</artifactId>
+      								<versionRange>
+      									[1.0,)
+      								</versionRange>
+      								<goals>
+      									<goal>enforce</goal>
+      									<goal>display-info</goal>
       								</goals>
       							</pluginExecutionFilter>
       							<action>


### PR DESCRIPTION
This modification allows to correctly import this project in Eclipse using m2e and the buildhelper connector. Moreover, it ignores a few additional goals which are not covered by m2e