### PR TITLE
implemented ability to add more vnc parameters like enabling extensions

### DIFF
--- a/src/main/java/hudson/plugins/xvnc/Xvnc.java
+++ b/src/main/java/hudson/plugins/xvnc/Xvnc.java
@@ -49,6 +49,9 @@ public class Xvnc extends SimpleBuildWrapper {
      */
     @DataBoundSetter
     public boolean takeScreenshot;
+	
+	@DataBoundSetter
+    public String additionalArgs = null;
 
     @DataBoundSetter
     public Boolean useXauthority = true;
@@ -92,7 +95,7 @@ public class Xvnc extends SimpleBuildWrapper {
 
         String cmd = Util.nullify(DESCRIPTOR.xvnc);
         if (cmd == null) {
-            cmd = "vncserver :$DISPLAY_NUMBER -localhost -nolisten tcp";
+            cmd = "vncserver :$DISPLAY_NUMBER -localhost -nolisten tcp " + (this.additionalArgs != null ? this.additionalArgs : "");
         }
 
         workspace.mkdirs();


### PR DESCRIPTION
You might wan to adjust screen size or simply enable an extension, which is currently not possible as far as I saw. So why not enabling the ability to provide any further arguments to vncserver start.