### PR TITLE
Make sure the plugin supports RHEL 8 tigervnc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,11 @@
 #!/usr/bin/env groovy
 
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-// There is no need to test this on Windows as the plugins is not supposed to be used there
-buildPlugin(platforms: ["linux"])
+node('docker') {
+    docker.image('jenkins/ath:acceptance-test-harness-1.73').inside {
+        stage('test') {
+            checkout scm
+            sh 'mvn -B --no-transfer-progress clean package'
+            junit '**/target/surefire-reports/TEST-*.xml'
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+// There is no need to test this on Windows as the plugins is not supposed to be used there
+buildPlugin(platforms: ["linux"])

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <jenkins.version>1.609.1</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>1.612</jenkins.version>
+    <java.level>7</java.level>
     <workflow.version>1.8</workflow.version>
   </properties>
     <dependencies>

--- a/src/main/resources/hudson/plugins/xvnc/Xvnc/help-commandline.html
+++ b/src/main/resources/hudson/plugins/xvnc/Xvnc/help-commandline.html
@@ -7,5 +7,6 @@
   See <a href="http://www.realvnc.com/products/free/4.1/man/vncserver.html">the man page</a>
   for more details. Hudson remembers what display numbers are in use, and when it launches
   a new vncserver process, it picks the available number and replace <tt>$DISPLAY_NUMBER</tt>
-  by that number.
+  by that number. Additionally, commandline can be provided and while letting the plugin to locate the vnc server binary:
+  <tt>$VNC_COMMAND :$DISPLAY_NUMBER -geometry 800x600</tt>
 </div>

--- a/src/main/resources/hudson/plugins/xvnc/Xvnc/help-commandline.html
+++ b/src/main/resources/hudson/plugins/xvnc/Xvnc/help-commandline.html
@@ -1,12 +1,12 @@
 <div>
-  Configure the Xvnc command line to invoke. Leave it empty to let Hudson figures things out.
+  Configure the Xvnc command line to invoke. Leave it empty to let Jenkins figure things out.
   <br>
   Xvnc must be installed on the system
   <br>
   A typical option looks like "<tt>/path/to/vncserver :$DISPLAY_NUMBER -geometry 800x600</tt>"
   See <a href="http://www.realvnc.com/products/free/4.1/man/vncserver.html">the man page</a>
-  for more details. Hudson remembers what display numbers are in use, and when it launches
+  for more details. Jenkins remembers what display numbers are in use, and when it launches
   a new vncserver process, it picks the available number and replace <tt>$DISPLAY_NUMBER</tt>
-  by that number. Additionally, commandline can be provided and while letting the plugin to locate the vnc server binary:
+  by that number. Additionally, commandline can be provided while letting the plugin to locate the vnc server binary:
   <tt>$VNC_COMMAND :$DISPLAY_NUMBER -geometry 800x600</tt>
 </div>

--- a/src/main/resources/hudson/plugins/xvnc/Xvnc/help-maxDisplayNumber.html
+++ b/src/main/resources/hudson/plugins/xvnc/Xvnc/help-maxDisplayNumber.html
@@ -1,6 +1,6 @@
 <div>
-  Maximum X display number to use when starting Xvnc. Leave it empty to let Hudson figures things out.
+  Maximum X display number to use when starting Xvnc. Leave it empty to let Jenkins figures things out.
   <br>
   Default is 99. A random display number will be chosen between minimum and maximum given, inclusive. Use a number only, don't prepend the colon (:).
-  Note that some vnc viewers interepret the display numbers above 99 as socket port numbers and leave out offseting with 5900.
+  Note that some vnc viewers interpret the display numbers above 99 as socket port numbers and leave out offseting with 5900.
 </div>

--- a/src/main/resources/hudson/plugins/xvnc/Xvnc/help-minDisplayNumber.html
+++ b/src/main/resources/hudson/plugins/xvnc/Xvnc/help-minDisplayNumber.html
@@ -1,5 +1,5 @@
 <div>
-  Minimum X display number to use when starting Xvnc. Leave it empty to let Hudson figures things out.
+  Minimum X display number to use when starting Xvnc. Leave it empty to let Jenkins figures things out.
   <br>
   Default is 10. A random display number will be chosen between minimum and maximum given, inclusive. Use a number only, don't prepend the colon (:).
 </div>

--- a/src/main/resources/hudson/plugins/xvnc/Xvnc/help-skipOnWindows.html
+++ b/src/main/resources/hudson/plugins/xvnc/Xvnc/help-skipOnWindows.html
@@ -1,5 +1,5 @@
 <div>
-    If checked, Xvnc execution will skiped on all Windows machines, regardless of the job configuration.
-    This is useful for most users who use the Xvnc support to perform GUI tests inside Hudson, as
+    If checked, Xvnc execution will skipped on all Windows machines, regardless of the job configuration.
+    This is useful for most users who use the Xvnc support to perform GUI tests inside Jenkins, as
     tests run on Windows won't use the X protocol anyway.
 </div>

--- a/src/test/java/hudson/plugins/xvnc/XvncTest.java
+++ b/src/test/java/hudson/plugins/xvnc/XvncTest.java
@@ -118,6 +118,16 @@ public class XvncTest {
     }
 
     @Test
+    public void vncCommandVariable() throws Exception {
+        FreeStyleProject p = j.jenkins.createProject(FreeStyleProject.class, "project");
+
+        runXvnc(p, true, false).xvnc = "$VNC_COMMAND -nocursor :$DISPLAY_NUMBER";
+
+        FreeStyleBuild build = j.buildAndAssertSuccess(p);
+        j.assertLogContains(" -nocursor :", build);
+    }
+
+    @Test
     public void displayBlacklistedOnOneMachineShouldNotBeBlacklistedOnAnother() throws Exception {
         DumbSlave slaveA = j.createOnlineSlave();
         DumbSlave slaveB = j.createOnlineSlave();


### PR DESCRIPTION
The versions have removed the `vncserver` wrappers so plain old `Xvnc` needs to be used instead. Also, the `import` does not seem to be around, but there are alternatives.